### PR TITLE
Fix test script to detect CMake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Requirements:
    ```bash
    make -j4
    ```
+   If you prefer to build using a C++ compiler such as `g++`, run:
+   ```bash
+   make CC=g++ CC_LINK=g++ CFLAGS="-x c" -j4 mathomatic
+   ```
 4. (Optional) Run the test suite:
    ```bash
    cd ..

--- a/makefile
+++ b/makefile
@@ -178,8 +178,13 @@ $(MATHOMATIC_OBJECTS): $(INCLUDES) VERSION
 static: LDFLAGS += -static
 
 # Create the mathomatic executable:
+# Allow using a different compiler for linking when compiling with a C++
+# compiler that requires special flags for C sources.  By default CC_LINK is
+# the same as CC.
+CC_LINK ?= $(CC)
+
 $(AOUT): $(MATHOMATIC_OBJECTS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $+ $(LDLIBS) -o $(AOUT)
+	$(CC_LINK) $(LDFLAGS) $+ $(LDLIBS) -o $(AOUT)
 	@echo
 	@echo ./$(AOUT) successfully created.
 

--- a/t
+++ b/t
@@ -1,11 +1,22 @@
 #!/bin/sh
 # Shell script to test Mathomatic.
+#
+# This script now supports running the test suite after building with
+# the provided CMake configuration.  If a mathomatic executable exists
+# in the repository root we use the existing Makefile targets, otherwise
+# we look for one in the "build" directory.
 
-if make --version >/dev/null 2>&1
-then
-	set -x
-	make test
+set -e
+
+if [ -x ./mathomatic ]; then
+    set -x
+    make check
+elif [ -x ./build/mathomatic ]; then
+    echo "Running tests using ./build/mathomatic"
+    set -x
+    cd tests && ../build/mathomatic -t all 0<&- >test.out && diff -u --strip-trailing-cr all.out test.out && rm test.out && cd ..
+    echo "All tests passed 100% correctly."
 else
-	set -x
-	gmake test
+    echo "mathomatic executable not found. Please build it first." >&2
+    exit 1
 fi


### PR DESCRIPTION
## Summary
- allow `t` to run tests using `build/mathomatic`
- show success message even when the binary is built with CMake
- add `CC_LINK` in Makefile so C++ compilers can link without `-x c`
- document building with g++

## Testing
- `CC=g++ CC_LINK=g++ CFLAGS="-x c" make -j4 mathomatic`
- `./t`

------
https://chatgpt.com/codex/tasks/task_e_68457f375774832a9882a8f524bc56a7